### PR TITLE
fix #2 allow invocation with existing element for first parameter

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var crel = require('crel');
 
 module.exports = function(namespace, type){
-    var element = document.createElementNS(namespace, type);
+    var element = crel.isElement(element) ? element : document.createElementNS(namespace, type);
     return crel.apply(null, [element].concat(Array.prototype.slice.call(arguments, 2)));
 };

--- a/test/index.js
+++ b/test/index.js
@@ -46,3 +46,41 @@ test('create g with a child', function(t) {
 
     t.end();
 });
+
+test('create circle with attributes', function(t) {
+    t.plan(2);
+
+    var testElement = crelns('http://www.w3.org/2000/svg', 'circle', {'class':'mycircle',cx:50,cy:50,r:25});
+
+    t.deepEqual(
+        testElement.className,
+        {animVal:'mycircle',baseVal:'mycircle'}
+    );
+
+    t.deepEqual(
+        testElement.cx.baseVal,
+        {value:50,valueInSpecifiedUnits:50}
+    );
+
+    t.end();
+});
+
+test('modify existing circle attributes', function(t) {
+    t.plan(2);
+
+    var testElement = crelns('http://www.w3.org/2000/svg', 'circle', {'class':'mycircle',cx:50,cy:50,r:25});
+
+    t.deepEqual(
+        testElement.r.baseVal,
+        {value:25,valueInSpecifiedUnits:25}
+    );
+
+    testElement = crelns('http://www.w3.org/2000/svg', testElement, {r:45});
+
+    t.deepEqual(
+        testElement.r.baseVal,
+        {value:45,valueInSpecifiedUnits:45}
+    );
+
+    t.end();
+});


### PR DESCRIPTION
Here is the changes and test cases to support invocation of `crelns` with an existing element.

Unfortunately, I got some dramatic changes in `test/index.browser.js` so I did not include that change. I assume this is due to settings differences or changes to `browserify` since `crelns` was last published.

Thank you!